### PR TITLE
feat: enable packaging for tagged commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+      - name: Install templ
+        run: go install github.com/a-h/templ/cmd/templ@latest
+      - name: Generate templ files
+        run: templ generate    
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,51 @@
+# .goreleaser.yml for HPI Mensa API
+version: 2
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+    main: ./cmd/hpi-mensa-api/main.go
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+    - goos: windows
+      format: zip
+release:
+  github:
+    owner: SLH335
+    name: hpi-mensa-api
+nfpms:
+  - id: nfpms
+    file_name_template: "{{ .ConventionalFileName }}"
+    package_name: hpi-mensa-api
+    maintainer: SLH335
+    description: An API to get data about meals at Hasso Plattner Institute and University of Potsdam
+    homepage: https://github.com/RocketRene/hpi-mensa-api
+    license: MIT
+    formats:
+      - deb
+      - rpm
+publishers:
+  - name: fury.io
+    ids:
+      - nfpms
+    cmd: |
+      curl -F package=@{{ .ArtifactPath }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/rocketrene/
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
# Add GoReleaser Configuration and GitHub Actions Workflow

This PR introduces automated releases for the HPI Mensa API project using GoReleaser and GitHub Actions.

## Key Changes:

- Add `.goreleaser.yml` configuration file
  - Configure builds for Linux (amd64)
  - Set up NFPM for .deb and .rpm package creation
  - Configure Fury.io as a publisher for packages

- Add GitHub Actions workflow for releases
  - Trigger on push of version tags
  - Install and run `templ` for template generation
  - Execute GoReleaser for building and publishing


These changes will automate the release process, generating Linux packages and publishing them to both GitHub Releases and Fury.io repository.

## Important: Action Required

For this workflow to function correctly, the repository owner needs to add the following secret to the GitHub repository:

- `FURY_TOKEN`: The  Fury.io API token for package uploads, that I have sent via dm.

To add this secret:
1. Go to the repository's Settings
2. Navigate to Secrets and variables > Actions
3. Click on "New repository secret"
4. Name it `FURY_TOKEN` and paste your Fury.io API token as the value

![image](https://github.com/user-attachments/assets/7d27bf3b-025b-429e-9bcd-80da09858d1f)


Without this secret, the workflow will fail to upload packages to Fury.io.